### PR TITLE
Build - circle ci recommends using machine vs docker for testcontainers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ jobs:
   build_and_test:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
+    machine:
       # specify the version you desire here
-      - image: cimg/openjdk:11.0
+      - image: ubuntu-2204:2022.04.1
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/pom.xml
+++ b/pom.xml
@@ -1113,8 +1113,8 @@
 						<!-- Reflow skin requires Velocity >= 1.7 -->
                         <dependency>
                             <groupId>org.apache.velocity</groupId>
-                            <artifactId>velocity</artifactId>
-                            <version>1.7</version>
+                            <artifactId>velocity-engine-core</artifactId>
+                            <version>2.3</version>
                         </dependency>
                         <dependency>
                             <groupId>org.apache.maven.skins</groupId>


### PR DESCRIPTION
CHANGE - circle ci to use VM machine vs docker